### PR TITLE
force requests response to utf-8

### DIFF
--- a/sickle/app.py
+++ b/sickle/app.py
@@ -114,6 +114,7 @@ class Sickle(object):
                 time.sleep(retry_after)
             else:
                 http_response.raise_for_status()
+                http_response.encoding = 'utf-8'
                 return OAIResponse(http_response, params=kwargs)
 
     def ListRecords(self, ignore_deleted=False, **kwargs):


### PR DESCRIPTION
Record.raw appear as unicode, but its content seems always ISO-8859-1
it's correct to force requests response encoding?
