### PR TITLE
Add argument to XML parser to prohibit loading entities

### DIFF
--- a/sickle/response.py
+++ b/sickle/response.py
@@ -8,7 +8,7 @@
 
 from lxml import etree
 
-XMLParser = etree.XMLParser(remove_blank_text=True, recover=True)
+XMLParser = etree.XMLParser(remove_blank_text=True, recover=True, resolve_entities=False)
 
 
 class OAIResponse(object):


### PR DESCRIPTION
Description of problem, and the fix for it, at this URL:
https://mikeknoop.com/lxml-xxe-exploit/