### PR TITLE
Apply retry logic to all 5xx return codes

### DIFF
--- a/sickle/app.py
+++ b/sickle/app.py
@@ -108,13 +108,13 @@ class Sickle(object):
             else:
                 http_response = requests.post(self.endpoint, data=kwargs,
                                               **self.request_args)
-            if http_response.status_code == 503:
+            if 500 <= http_response.status_code <= 599:
                 try:
                     retry_after = int(http_response.headers.get('retry-after'))
                 except TypeError:
                     retry_after = 20
                 logger.info(
-                    "HTTP 503! Retrying after %d seconds..." % retry_after)
+                    "HTTP %d! Retrying after %d seconds..." % (http_response.status_code, retry_after))
                 time.sleep(retry_after)
             else:
                 http_response.raise_for_status()

--- a/sickle/tests/test_sickle.py
+++ b/sickle/tests/test_sickle.py
@@ -29,7 +29,7 @@ class TestCase(unittest.TestCase):
         Sickle("http://localhost", iterator=None)
 
     def test_pass_request_args(self):
-        mock_response = Mock(text='<xml/>')
+        mock_response = Mock(text='<xml/>', status_code=200)
         mock_get = Mock(return_value=mock_response)
         with patch('sickle.app.requests.get', mock_get):
             sickle = Sickle('url', timeout=10, proxies=dict(),
@@ -41,7 +41,7 @@ class TestCase(unittest.TestCase):
                                              auth=('user', 'password'))
 
     def test_override_encoding(self):
-        mock_response = Mock(text='<xml/>')
+        mock_response = Mock(text='<xml/>', status_code=200)
         mock_get = Mock(return_value=mock_response)
         with patch('sickle.app.requests.get', mock_get):
             sickle = Sickle('url', encoding='encoding')


### PR DESCRIPTION
I have encountered a site that likes to return 504s.  Retries appear to work with them.  I'd like to expand the logic in Sickle to handle it.