### PR TITLE
Pass lxml.etree response.content instead of response.text.encode('utf8')

### DIFF
--- a/sickle/response.py
+++ b/sickle/response.py
@@ -34,7 +34,7 @@ class OAIResponse(object):
     @property
     def xml(self):
         """The server's response as parsed XML."""
-        return etree.XML(self.http_response.text.encode("utf8"),
+        return etree.XML(self.http_response.content,
                          parser=XMLParser)
 
     def __repr__(self):

--- a/sickle/tests/sample_data/GetRecord_utf8test.xml
+++ b/sickle/tests/sample_data/GetRecord_utf8test.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<OAI-PMH xmlns="http://www.openarchives.org/OAI/2.0/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/ http://www.openarchives.org/OAI/2.0/OAI-PMH.xsd">
+    <responseDate>2013-02-27T10:07:54Z</responseDate>
+    <request identifier="oai:test.example.com:1996652" metadataPrefix="oai_dc" verb="GetRecord">
+        http://test.example.com/oai
+    </request>
+    <GetRecord>
+        <record>
+            <header>
+                <identifier>oai:test.example.com:1996652</identifier>
+                <datestamp>2011-09-05T12:51:52Z</datestamp>
+            </header>
+            <metadata>
+                <oai_dc:dc xmlns:dc="http://purl.org/dc/elements/1.1/"
+                           xmlns:oai_dc="http://www.openarchives.org/OAI/2.0/oai_dc/"
+                           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                           xsi:schemaLocation="http://www.openarchives.org/OAI/2.0/oai_dc/ http://www.openarchives.org/OAI/2.0/oai_dc.xsd">
+                    <dc:title>Sample Title</dc:title>
+                    <dc:identifier>http://test.example.com/publication/1996652</dc:identifier>
+                    <dc:creator>某人</dc:creator>
+                    <dc:language>eng</dc:language>
+                    <dc:source>Sample Source</dc:source>
+                    <dc:publisher>Sample Publisher</dc:publisher>
+                    <dc:date>2011</dc:date>
+                    <dc:type>text</dc:type>
+                </oai_dc:dc>
+            </metadata>
+        </record>
+    </GetRecord>
+</OAI-PMH>

--- a/sickle/tests/test_harvesting.py
+++ b/sickle/tests/test_harvesting.py
@@ -196,3 +196,65 @@ class TestCase(unittest.TestCase):
         sickle = Sickle('fake_url', iterator=OAIResponseIterator)
         records = [r for r in sickle.ListRecords(metadataPrefix='oai_dc')]
         self.assertEqual(len(records), 4)
+
+
+def mock_get(*args, **kwargs):
+    class MockResponseWrongEncoding(object):
+        """Mimics a case where the requests library misidentifies the text encoding.
+
+        If http headers do not specify the correct encoding, requests will default
+        to 'ISO-8859-1', even though the oai-pmh document might specify e.g.
+        <xml encoding='utf-8'>.
+
+        Parameters
+        ----------
+        filename : str
+            Name of a utf8-encoded test file in the sample_data directory.
+
+        Attributes
+        ----------
+        content : bytes (py3) / str (py2)
+            Raw utf8-encoded bytestream
+        text : str (py3) / unicode (py2)
+            Unicode string from self.content, but wrongly decoded as ISO-8859-1
+        status_code : int
+            = 200
+        """
+
+        def __init__(self, filename='GetRecord_utf8test.xml'):
+            with open(os.path.join(this_dir, 'sample_data', filename), 'rb') as fp:
+                self.content = fp.read()
+            self.text = self.content.decode('ISO-8859-1')
+            self.status_code = 200
+
+        def raise_for_status(self):
+            pass
+
+    return MockResponseWrongEncoding()
+
+
+class TestCaseWrongEncoding(unittest.TestCase):
+
+    def __init__(self, methodName='runTest'):
+        super(TestCaseWrongEncoding, self).__init__(methodName)
+        self.patch = mock.patch('sickle.app.requests.get', mock_get)
+
+    def setUp(self):
+        self.patch.start()
+        self.sickle = Sickle('http://localhost')
+
+    def tearDown(self):
+        self.patch.stop()
+
+    def test_GetRecord(self):
+        oai_id = 'oai:test.example.com:1996652'
+        record = self.sickle.GetRecord(identifier=oai_id)
+        self.assertEqual(record.header.identifier, oai_id)
+        self.assertIn(oai_id, record.raw)
+        self.assertEqual(record.header.datestamp, '2011-09-05T12:51:52Z')
+        self.assertIsInstance(record.xml, etree._Element)
+        binary_type(record)
+        text_type(record)
+        dict(record.header)
+        self.assertEqual(dict(record), record.metadata)
+        self.assertIn(u'某人', record.metadata['creator'])

--- a/sickle/tests/test_harvesting.py
+++ b/sickle/tests/test_harvesting.py
@@ -30,6 +30,7 @@ class MockResponse(object):
         # request's response object carry an attribute 'text' which contains
         # the server's response data encoded as unicode.
         self.text = text
+        self.content = text.encode('utf-8')
 
 
 def mock_harvest(*args, **kwargs):

--- a/sickle/tests/test_sickle.py
+++ b/sickle/tests/test_sickle.py
@@ -29,7 +29,7 @@ class TestCase(unittest.TestCase):
         Sickle("http://localhost", iterator=None)
 
     def test_pass_request_args(self):
-        mock_response = Mock(text='<xml/>')
+        mock_response = Mock(text=u'<xml/>', content='<xml/>')
         mock_get = Mock(return_value=mock_response)
         with patch('sickle.app.requests.get', mock_get):
             sickle = Sickle('url', timeout=10, proxies=dict(),
@@ -41,7 +41,7 @@ class TestCase(unittest.TestCase):
                                              auth=('user', 'password'))
 
     def test_override_encoding(self):
-        mock_response = Mock(text='<xml/>')
+        mock_response = Mock(text='<xml/>', content='<xml/>')
         mock_get = Mock(return_value=mock_response)
         with patch('sickle.app.requests.get', mock_get):
             sickle = Sickle('url', encoding='encoding')


### PR DESCRIPTION
cf. https://github.com/mloesch/sickle/issues/20, https://github.com/mloesch/sickle/issues/22