### PR TITLE
try/except block to catch AttributeErrors in OAI records w/ no metadata child

### DIFF
--- a/sickle/models.py
+++ b/sickle/models.py
@@ -132,16 +132,7 @@ class Record(OAIItem):
             './/' + self._oai_namespace + 'header'))
         self.deleted = self.header.deleted
         if not self.deleted:
-            # We want to get record/metadata/<container>/*
-            # <container> would be the element ``dc``
-            # in the ``oai_dc`` case.
-            try:
-                self.metadata = xml_to_dict(
-                    self.xml.find(
-                        './/' + self._oai_namespace + 'metadata'
-                    ).getchildren()[0], strip_ns=self._strip_ns)
-            except AttributeError:
-                self.metadata = None
+            self.metadata = self.get_metadata()
 
     def __repr__(self):
         if self.header.deleted:
@@ -152,6 +143,15 @@ class Record(OAIItem):
     def __iter__(self):
         return iter(self.metadata.items()) if PY3 else \
             self.metadata.iteritems()
+
+    def get_metadata(self):
+        # We want to get record/metadata/<container>/*
+        # <container> would be the element ``dc``
+        # in the ``oai_dc`` case.
+        return xml_to_dict(
+            self.xml.find(
+                './/' + self._oai_namespace + 'metadata'
+            ).getchildren()[0], strip_ns=self._strip_ns)
 
 
 class Set(OAIItem):

--- a/sickle/models.py
+++ b/sickle/models.py
@@ -135,10 +135,13 @@ class Record(OAIItem):
             # We want to get record/metadata/<container>/*
             # <container> would be the element ``dc``
             # in the ``oai_dc`` case.
-            self.metadata = xml_to_dict(
-                self.xml.find(
-                    './/' + self._oai_namespace + 'metadata'
-                ).getchildren()[0], strip_ns=self._strip_ns)
+            try:
+                self.metadata = xml_to_dict(
+                    self.xml.find(
+                        './/' + self._oai_namespace + 'metadata'
+                    ).getchildren()[0], strip_ns=self._strip_ns)
+            except AttributeError:
+                self.metadata = None
 
     def __repr__(self):
         if self.header.deleted:


### PR DESCRIPTION
Fix for issue #37 