### PR TITLE
do not return None from harvest

### DIFF
--- a/sickle/app.py
+++ b/sickle/app.py
@@ -122,6 +122,8 @@ class Sickle(object):
                     http_response.encoding = self.encoding
                 return OAIResponse(http_response, params=kwargs)
 
+        raise TimeoutError("max retries (%d) exceeded for %s" % (self.max_retries, self.endpoint))
+
     def ListRecords(self, ignore_deleted=False, **kwargs):
         """Issue a ListRecords request.
 

--- a/sickle/tests/test_harvesting.py
+++ b/sickle/tests/test_harvesting.py
@@ -259,3 +259,20 @@ class TestCaseWrongEncoding(unittest.TestCase):
         dict(record.header)
         self.assertEqual(dict(record), record.metadata)
         self.assertIn(u'某人', record.metadata['creator'])
+
+class TestHarvestTimeout(unittest.TestCase):
+
+    def __init__(self, methodName='runTest'):
+        super(TestHarvestTimeout, self).__init__(methodName)
+        self.patch = mock.patch('sickle.app.requests.get', mock_get)
+
+    def setUp(self):
+        self.patch.start()
+        self.sickle = Sickle('http://localhost', max_retries=0)
+
+    def tearDown(self):
+        self.patch.stop()
+
+    def test_harvest(self):
+        with self.assertRaises(TimeoutError):
+            self.sickle.harvest()


### PR DESCRIPTION
It can happen, that harvest returns None, e.g. when an endpoint returns
503 Service Unavailable repeatedly.

However, there is an assumption that response will not be None during
iteration:

    self.oai_response = self.sickle.harvest(**params)
    error = self.oai_response.xml.find(

This yields an 'NoneType' object has no attribute 'xml' error.

Hence, when max_retries is exceeded, a TimeoutError would be a bit more
clear.