### PR TITLE
Fix 'NoneType' object has no attribute 'getchildren' error.

### DIFF
--- a/sickle/iterator.py
+++ b/sickle/iterator.py
@@ -146,6 +146,8 @@ class OAIItemIterator(BaseOAIIterator):
                 mapped = self.mapper(item)
                 if self.ignore_deleted and mapped.deleted:
                     continue
+                if hasattr(mapped, 'metadata') and mapped.metadata == None:
+                    continue
                 return mapped
             if self.resumption_token and self.resumption_token.token:
                 self._next_response()

--- a/sickle/models.py
+++ b/sickle/models.py
@@ -148,10 +148,9 @@ class Record(OAIItem):
         # We want to get record/metadata/<container>/*
         # <container> would be the element ``dc``
         # in the ``oai_dc`` case.
-        return xml_to_dict(
-            self.xml.find(
-                './/' + self._oai_namespace + 'metadata'
-            ).getchildren()[0], strip_ns=self._strip_ns)
+        meta_data = self.xml.find('.//' + self._oai_namespace + 'metadata')
+        if meta_data != None:
+            return xml_to_dict(meta_data.getchildren()[0], strip_ns=self._strip_ns)
 
 
 class Set(OAIItem):

--- a/sickle/tests/sample_data/ListRecords.xml
+++ b/sickle/tests/sample_data/ListRecords.xml
@@ -46,6 +46,13 @@
                 </oai_dc:dc>
             </metadata>
         </record>
+        <record>
+          <header>
+            <identifier>oai:digital.librarycompany.org:digitool_55043</identifier>
+            <datestamp>2018-11-28T16:18:30Z</datestamp>
+            <setSpec>Islandora_CVMC1</setSpec>
+          </header>
+        </record>
         <resumptionToken completeListSize="8" cursor="0">ListRecords2.xml</resumptionToken>
     </ListRecords>
 </OAI-PMH>


### PR DESCRIPTION
We're running into an issue where we are trying to harvest an OAI
endpoint where one of the records has no metadata and its status is not
set to deleted.

The error we get for this record is at iteration time:

```
AttributeError: 'NoneType' object has no attribute 'getchildren'
```

This change updates the code so that it skips a record that has no
metadata. Thus, the exception is not thrown.