### PR TITLE
Add support for sessions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: false
 language: python
 python:
     - "2.7"

--- a/sickle/app.py
+++ b/sickle/app.py
@@ -111,6 +111,7 @@ class Sickle(object):
         self.class_mapping = class_mapping or DEFAULT_CLASS_MAP
         self.encoding = encoding
         self.request_args = request_args
+        self.session = requests.Session()
 
     def harvest(self, **kwargs):  # pragma: no cover
         """Make HTTP requests to the OAI server.
@@ -134,8 +135,8 @@ class Sickle(object):
 
     def _request(self, kwargs):
         if self.http_method == 'GET':
-            return requests.get(self.endpoint, params=kwargs, **self.request_args)
-        return requests.post(self.endpoint, data=kwargs, **self.request_args)
+            return self.session.get(self.endpoint, params=kwargs, **self.request_args)
+        return self.session.post(self.endpoint, data=kwargs, **self.request_args)
 
     def ListRecords(self, ignore_deleted=False, **kwargs):
         """Issue a ListRecords request.

--- a/sickle/tests/test_harvesting.py
+++ b/sickle/tests/test_harvesting.py
@@ -10,6 +10,7 @@ import unittest
 
 from lxml import etree
 from nose.tools import raises
+from requests import Session
 import mock
 
 from sickle import Sickle
@@ -238,7 +239,7 @@ class TestCaseWrongEncoding(unittest.TestCase):
 
     def __init__(self, methodName='runTest'):
         super(TestCaseWrongEncoding, self).__init__(methodName)
-        self.patch = mock.patch('sickle.app.requests.get', mock_get)
+        self.patch = mock.patch.object(Session, 'get', mock_get)
 
     def setUp(self):
         self.patch.start()

--- a/sickle/tests/test_sickle.py
+++ b/sickle/tests/test_sickle.py
@@ -11,6 +11,7 @@ import unittest
 from mock import patch, Mock
 from nose.tools import raises
 from requests import HTTPError
+from requests import Session
 
 from sickle import Sickle
 
@@ -33,7 +34,7 @@ class TestCase(unittest.TestCase):
     def test_pass_request_args(self):
         mock_response = Mock(text=u'<xml/>', content='<xml/>', status_code=200)
         mock_get = Mock(return_value=mock_response)
-        with patch('sickle.app.requests.get', mock_get):
+        with patch.object(Session, 'get', mock_get):
             sickle = Sickle('url', timeout=10, proxies=dict(),
                             auth=('user', 'password'))
             sickle.ListRecords()
@@ -45,7 +46,7 @@ class TestCase(unittest.TestCase):
     def test_override_encoding(self):
         mock_response = Mock(text='<xml/>', content='<xml/>', status_code=200)
         mock_get = Mock(return_value=mock_response)
-        with patch('sickle.app.requests.get', mock_get):
+        with patch.object(Session, 'get', mock_get):
             sickle = Sickle('url', encoding='encoding')
             sickle.ListSets()
             mock_get.assert_called_once_with('url',
@@ -56,7 +57,7 @@ class TestCase(unittest.TestCase):
                              headers={'retry-after': '10'},
                              raise_for_status=Mock(side_effect=HTTPError))
         mock_get = Mock(return_value=mock_response)
-        with patch('sickle.app.requests.get', mock_get):
+        with patch.object(Session, 'get', mock_get):
             sickle = Sickle('url')
             try:
                 sickle.ListRecords()
@@ -71,7 +72,7 @@ class TestCase(unittest.TestCase):
         mock_get = Mock(return_value=mock_response)
         sleep_mock = Mock()
         with patch('time.sleep', sleep_mock):
-            with patch('sickle.app.requests.get', mock_get):
+            with patch.object(Session, 'get', mock_get):
                 sickle = Sickle('url', max_retries=3, default_retry_after=0)
                 try:
                     sickle.ListRecords()
@@ -87,7 +88,7 @@ class TestCase(unittest.TestCase):
         mock_response = Mock(status_code=500,
                              raise_for_status=Mock(side_effect=HTTPError))
         mock_get = Mock(return_value=mock_response)
-        with patch('sickle.app.requests.get', mock_get):
+        with patch.object(Session, 'get', mock_get):
             sickle = Sickle('url', max_retries=3, default_retry_after=0, retry_status_codes=(503, 500))
             try:
                 sickle.ListRecords()


### PR DESCRIPTION
This is a minor PR adding support for sessions while using `requests`. By using sessions, `requests` can reuse the same TCP connection while making requests to the same host, which might increase performance. Moreover, sessions allow saving cookies data, which is crucial in our 4 server deployment of OAI at the National Library of Norway.