### PR TITLE
Add a warning if a server sends back non-XML

### DIFF
--- a/sickle/response.py
+++ b/sickle/response.py
@@ -6,6 +6,7 @@
     :copyright: Copyright 2015 Mathias Loesch
 """
 
+import logging
 from lxml import etree
 
 XMLParser = etree.XMLParser(remove_blank_text=True, recover=True, resolve_entities=False)
@@ -34,6 +35,10 @@ class OAIResponse(object):
     @property
     def xml(self):
         """The server's response as parsed XML."""
+        if (self.http_response.headers.get('Content-Type') !=
+            'application/xml'):
+            logging.warn('received non-XML response %s',
+                         self.http_response.headers.get('Content-Type'))
         return etree.XML(self.http_response.content,
                          parser=XMLParser)
 


### PR DESCRIPTION
https://data.csiro.au/dap/ws/v2/collections is an example of a server that sends back JSON rather than XML to a sickle request by default.

Adding headers={'Accept': 'application/xml'} to the Sickle() constructor fixes that, but it was a bit of digging to work out why. This logging message would have saved me a bit of debugging time.